### PR TITLE
tests: reset modules + mocks between tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,8 @@ module.exports = {
   transform: {
     "^.+\\.jsx?$": "./jest-transformer.js"
   },
+  resetMocks: true,
+  resetModules: true,
   globals: {
     __DEV__: true
   }


### PR DESCRIPTION
- https://jestjs.io/docs/en/configuration#resetmodules-boolean
- https://jestjs.io/docs/en/configuration#resetmocks-boolean

It's not strictly required to reset _modules_ between tests, but given some of the Reach components use module state (ie the auto-id counter), it seems like a good idea to isolate them.

It is almost always a good idea to reset mocks.
