### PR TITLE
Tooltip - add beforeeach setup, add getByRole

### DIFF
--- a/packages/tooltip/src/index_.test.js
+++ b/packages/tooltip/src/index_.test.js
@@ -1,6 +1,5 @@
 import React from "react";
-import { render, fireEvent, act } from "@testing-library/react";
-import Tooltip, { LEAVE_TIMEOUT, MOUSE_REST_TIMEOUT } from ".";
+import { LEAVE_TIMEOUT, MOUSE_REST_TIMEOUT } from ".";
 
 jest.mock("@reach/utils", () => ({
   ...jest.requireActual("@reach/utils"),
@@ -14,9 +13,19 @@ function getTooltip(baseElement, trigger) {
   return tooltipPortal;
 }
 
+let Tooltip;
+let render, fireEvent, act, cleanup;
+
 describe("Tooltip", () => {
   beforeEach(() => {
+    ({ default: Tooltip } = require("."));
+    ({ cleanup, render, fireEvent, act } = require("@testing-library/react"));
+
     jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it("has correct markup", () => {
@@ -111,7 +120,7 @@ describe("Tooltip", () => {
 
   describe("with multiple Tooltips", () => {
     it("is only one tooltip visible at a time", () => {
-      const { baseElement, getByText } = render(
+      const { getAllByRole, getByText } = render(
         <>
           <Tooltip label="First">
             <button>First Trigger</button>
@@ -129,7 +138,7 @@ describe("Tooltip", () => {
       fireEvent.mouseLeave(firstTrigger);
       fireEvent.mouseOver(secondTrigger);
 
-      const tooltips = baseElement.querySelectorAll('[role="tooltip"]');
+      const tooltips = getAllByRole("tooltip");
       expect(tooltips).toHaveLength(1);
     });
 


### PR DESCRIPTION
```
% yarn test
yarn run v1.17.3
$ MODULE_FORMAT=cjs jest packages
 PASS  packages/component-component/src/index.test.js
 PASS  packages/dialog/src/index.test.js
 PASS  packages/tooltip/src/index.test.js
 PASS  packages/tooltip/src/index_.test.js

Test Suites: 4 passed, 4 total
Tests:       32 passed, 32 total
Snapshots:   24 passed, 24 total
Time:        2.636s
Ran all test suites matching /packages/i.
✨  Done in 4.00s.
```